### PR TITLE
Fix layout issues

### DIFF
--- a/addon/styles/addon.css
+++ b/addon/styles/addon.css
@@ -159,7 +159,7 @@ body {
 .field-guide-show-sidenav {
   display: none;
 
-  position: absolute;
+  position: fixed;
   top:5px;
   left:5px;
 

--- a/addon/styles/addon.css
+++ b/addon/styles/addon.css
@@ -2,7 +2,7 @@
  * This is the only resetting we will do. Any other resets need to come from
  * the addon itself. We recommend implementing normalize.css
  */
-body {
+ body {
   margin: 0;
 }
 
@@ -18,6 +18,7 @@ body {
   top: 0;
   left: 0;
   bottom: 0;
+  z-index: 1;
 
   display: flex;
   flex-direction: column;
@@ -28,7 +29,6 @@ body {
   border-right-color: #DDD;
   border-right-width: 1px;
   border-right-style: solid;
-
 }
 
 .field-guide-logo {
@@ -97,12 +97,17 @@ body {
   display: flex;
   flex-direction: column;
   justify-content: space-between;
-
 }
 
 .field-guide-wrapper-full-height > main {
   margin-left: 241px;
   padding: 2em 4em;
+}
+
+.field-guide-main-content {
+  /* Create a new stacking context for a user's content. */
+  position: relative;
+  z-index: 0;
 }
 
 .field-guide-footer {
@@ -162,6 +167,7 @@ body {
   position: fixed;
   top:5px;
   left:5px;
+  z-index: 1;
 
   background: none;
 	color: inherit;

--- a/addon/styles/addon.css
+++ b/addon/styles/addon.css
@@ -143,7 +143,7 @@
 .field-guide-socials li {
   display: inline-block;
   padding: 0;
-  marign: 0;
+  margin: 0;
 }
 
 .self-executing-code-block {

--- a/addon/templates/application.hbs
+++ b/addon/templates/application.hbs
@@ -16,12 +16,12 @@
     </div>
   </nav>
   <div class="field-guide-wrapper-full-height">
-    <main>
-      <button class="field-guide-show-sidenav" {{action (mut showSideNav) (not showSideNav)}}>
-        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" height="25">
-          <path d="M4 10h24a2 2 0 0 0 0-4H4a2 2 0 0 0 0 4zm24 4H4a2 2 0 0 0 0 4h24a2 2 0 0 0 0-4zm0 8H4a2 2 0 0 0 0 4h24a2 2 0 0 0 0-4z"/>
-        </svg>
-      </button>
+    <button class="field-guide-show-sidenav" {{action (mut showSideNav) (not showSideNav)}}>
+      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" height="25">
+        <path d="M4 10h24a2 2 0 0 0 0-4H4a2 2 0 0 0 0 4zm24 4H4a2 2 0 0 0 0 4h24a2 2 0 0 0 0-4zm0 8H4a2 2 0 0 0 0 4h24a2 2 0 0 0 0-4z"/>
+      </svg>
+    </button>
+    <main class="field-guide-main-content">
       {{outlet}}
     </main>
     <footer class="field-guide-footer">


### PR DESCRIPTION
- Fixes the issue with the sidenav "show" button being scrolled with the main content.
- Fixes the issue with the sidenav being overlapped by the main content. Create a new stacking context for a user's content to allow safely use `z-index` in documented components (fixes https://github.com/ember-learn/ember-styleguide/issues/286).
- Fixes minor issues with formatting and spelling.